### PR TITLE
Dev

### DIFF
--- a/server/src/controllers/shows-controller.ts
+++ b/server/src/controllers/shows-controller.ts
@@ -47,7 +47,7 @@ router.get(
       if (!showEntry || !(showEntry instanceof Show)) {
         throw new NotFoundError('Show');
       }
-      if (!isShowDataOld(showEntry)) {
+      if (isShowDataOld(showEntry)) {
         console.log('Show data might be outdated');
         await updateShowEntry(showEntry);
       }

--- a/server/src/services/show-service.ts
+++ b/server/src/services/show-service.ts
@@ -157,10 +157,18 @@ export const updateShowEntry = async (showEntry: Show) => {
   );
   const showDiff: number =
     newShowTMDBData.number_of_seasons - showEntry.seasonCount;
-  if (showDiff) {
+  const episodeDiff: number =
+    newShowTMDBData.number_of_episodes - showEntry.episodeCount;
+
+  //if a new season or more episodes, we update the show
+  if (showDiff || episodeDiff) {
     const transaction: Transaction = await sequelize.transaction();
     try {
-      console.log(`Found ${showDiff} new Season(s)!`);
+      console.log(
+        showDiff
+          ? `Found ${showDiff} new Season(s)!`
+          : `Found ${episodeDiff} new episodes!`
+      );
       const newShowData: ShowData = await fetchTMDBShowFull(showEntry.tmdbId);
       const newSeasonsData: SeasonData[] = newShowData.seasons.slice(-showDiff);
       console.log(newSeasonsData);


### PR DESCRIPTION
This pull request enhances the logic for updating TV show entries by ensuring that updates are triggered when either the season or episode count changes, and improves the robustness and accuracy of the update process. The changes also introduce better error handling and transactional safety during updates.

**Improvements to show update logic:**

* The `updateShowEntry` function now checks for both new seasons and new episodes, triggering an update if either count has changed. This ensures show data stays current even when only episode counts are updated.
* The update process now uses a database transaction for all changes, with proper commit and rollback handling to maintain data integrity in case of errors.

**Controller and helper enhancements:**

* The show controller now calls `updateShowEntry` whenever the show data is detected as outdated, ensuring users always receive up-to-date information.
* The `isShowDataOld` utility is now imported and used in the controller to check for outdated show data.

**Code maintenance:**

* Updated imports in `shows-controller.ts` to include `updateShowEntry` for direct usage.