### PR TITLE
Dev

### DIFF
--- a/server/migrations/25251004172800-add-user-media-lists.ts
+++ b/server/migrations/25251004172800-add-user-media-lists.ts
@@ -1,0 +1,178 @@
+import { DataTypes, Transaction } from 'sequelize';
+import { QueryInterfaceContext } from '../src/util/db/migrator-db';
+
+const USER_MEDIA_LIST_ICONS: string[] = [
+  'fav-film',
+  'fav-show',
+  'fav-multi',
+  'film',
+  'show',
+  'season',
+  'multi',
+  'like',
+  'watchlist',
+  'other',
+] as const;
+
+module.exports = {
+  up: async ({ context: queryInterface }: QueryInterfaceContext) => {
+    //we wrap in a transaction
+    await queryInterface.sequelize.transaction(
+      async (transaction: Transaction) => {
+        //UserMediaList
+        await queryInterface.createTable(
+          'user_media_lists',
+          {
+            id: {
+              type: DataTypes.INTEGER,
+              primaryKey: true,
+              autoIncrement: true,
+            },
+            name: {
+              type: DataTypes.STRING,
+              allowNull: false,
+            },
+            auto_remove_items: {
+              type: DataTypes.BOOLEAN,
+              defaultValue: false,
+            },
+            can_be_modified: {
+              type: DataTypes.BOOLEAN,
+              defaultValue: true,
+            },
+            private: {
+              type: DataTypes.BOOLEAN,
+              defaultValue: false,
+            },
+            description: {
+              type: DataTypes.STRING,
+              allowNull: true,
+              defaultValue: '',
+            },
+            index_in_user_lists: {
+              type: DataTypes.INTEGER,
+              allowNull: false,
+              defaultValue: 0,
+            },
+            icon: {
+              type: DataTypes.ENUM(...USER_MEDIA_LIST_ICONS),
+              allowNull: false,
+              defaultValue: 'multi',
+            },
+            user_id: {
+              type: DataTypes.INTEGER,
+              allowNull: false,
+              unique: false,
+              onDelete: 'CASCADE',
+              onUpdate: 'CASCADE',
+              references: {
+                model: 'users',
+                key: 'id',
+              },
+            },
+            media_types: {
+              type: DataTypes.ARRAY(DataTypes.STRING),
+              allowNull: false,
+              defaultValue: ['Film', 'Show'],
+            },
+            locked_media_type: {
+              type: DataTypes.BOOLEAN,
+              defaultValue: false,
+            },
+            created_at: {
+              type: DataTypes.DATE,
+              defaultValue: DataTypes.NOW,
+            },
+            updated_at: {
+              type: DataTypes.DATE,
+              defaultValue: DataTypes.NOW,
+            },
+          },
+          { transaction }
+        );
+        await queryInterface.addIndex('user_media_lists', {
+          unique: true,
+          fields: ['user_id', 'name'],
+          transaction,
+        });
+        await queryInterface.addIndex('user_media_lists', {
+          unique: true,
+          fields: ['user_id', 'index_in_user_lists'],
+          transaction,
+        });
+
+        //UserMediaListItem
+        await queryInterface.createTable(
+          'user_media_list_items',
+          {
+            id: {
+              type: DataTypes.INTEGER,
+              primaryKey: true,
+              autoIncrement: true,
+            },
+            index_in_list: {
+              type: DataTypes.INTEGER,
+              allowNull: false,
+              defaultValue: 0,
+            },
+            user_list_id: {
+              type: DataTypes.INTEGER,
+              allowNull: false,
+              references: {
+                model: 'user_media_lists',
+                key: 'id',
+              },
+              onDelete: 'CASCADE',
+              onUpdate: 'CASCADE',
+            },
+            index_id: {
+              type: DataTypes.INTEGER,
+              allowNull: false,
+              references: {
+                model: 'index_media',
+                key: 'id',
+              },
+              onDelete: 'CASCADE',
+              onUpdate: 'CASCADE',
+            },
+            created_at: {
+              type: DataTypes.DATE,
+              defaultValue: DataTypes.NOW,
+            },
+            updated_at: {
+              type: DataTypes.DATE,
+              defaultValue: DataTypes.NOW,
+            },
+          },
+          { transaction }
+        );
+        await queryInterface.addIndex('user_media_list_items', {
+          unique: true,
+          fields: ['index_id', 'user_list_id'],
+          transaction,
+        });
+        await queryInterface.addIndex('user_media_list_items', {
+          unique: true,
+          fields: ['user_list_id', 'index_in_list'],
+          transaction,
+        });
+      }
+    );
+  },
+
+  down: async ({ context: queryInterface }: QueryInterfaceContext) => {
+    await queryInterface.sequelize.transaction(
+      async (transaction: Transaction) => {
+        await queryInterface.dropTable('user_media_list_items', {
+          transaction,
+        });
+        await queryInterface.dropTable('user_media_lists', { transaction });
+        //we clean the ENUM we created too
+        await queryInterface.sequelize.query(
+          'DROP TYPE IF EXISTS "enum_user_media_lists_icon";',
+          { transaction }
+        );
+      }
+    );
+  },
+};

--- a/server/src/models/users/user.ts
+++ b/server/src/models/users/user.ts
@@ -8,6 +8,8 @@ import {
 import { sequelize } from '../../util/db/initialize-db';
 import Rating from './rating';
 import { Session } from '..';
+import UserMediaList from './userMediaList';
+import { RatingData } from '../../../../shared/types/models';
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare id: CreationOptional<number>;
@@ -19,12 +21,21 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare lastActive: Date | null;
   declare isActive: boolean;
   declare isAdmin: boolean;
+  declare userLists?: UserMediaList[];
+  declare ratings?: RatingData[];
 
   static associate() {
     this.hasMany(Rating, {
       as: 'ratings',
       foreignKey: 'userId',
       constraints: false,
+    });
+    this.hasMany(UserMediaList, {
+      as: 'userLists',
+      foreignKey: 'userId',
+      hooks: true,
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
     });
     this.hasOne(Session);
   }

--- a/server/src/models/users/userMediaList.ts
+++ b/server/src/models/users/userMediaList.ts
@@ -32,7 +32,7 @@ class UserMediaList extends Model<
   declare mediaTypes: CreationOptional<MediaType[]>;
   declare icon: CreationOptional<UserMediaListIcon>;
   declare lockedMediaType: CreationOptional<boolean>;
-  declare canBeDeleted: CreationOptional<boolean>;
+  declare canBeModified: CreationOptional<boolean>;
   declare autoRemoveItems: CreationOptional<boolean>;
   declare private: CreationOptional<boolean>;
   declare createdAt: CreationOptional<Date>;
@@ -69,7 +69,7 @@ UserMediaList.init(
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },
-    canBeDeleted: {
+    canBeModified: {
       type: DataTypes.BOOLEAN,
       defaultValue: true,
     },

--- a/server/src/models/users/userMediaList.ts
+++ b/server/src/models/users/userMediaList.ts
@@ -15,6 +15,10 @@ import {
   MIN_LENGTH_DESCRIPTION,
   MIN_LENGTH_NAME,
 } from '../../../../shared/constants/user-media-list-constants';
+import {
+  USER_MEDIA_LIST_ICONS,
+  UserMediaListIcon,
+} from '../../../../shared/types/models';
 
 class UserMediaList extends Model<
   InferAttributes<UserMediaList>,
@@ -26,7 +30,11 @@ class UserMediaList extends Model<
   declare userId: number;
   declare indexInUserLists: number;
   declare mediaTypes: CreationOptional<MediaType[]>;
+  declare icon: CreationOptional<UserMediaListIcon>;
   declare lockedMediaType: CreationOptional<boolean>;
+  declare canBeDeleted: CreationOptional<boolean>;
+  declare autoRemoveItems: CreationOptional<boolean>;
+  declare private: CreationOptional<boolean>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare listItems?: UserMediaListItem[];
@@ -57,6 +65,18 @@ UserMediaList.init(
         min: MIN_LENGTH_NAME,
       },
     },
+    autoRemoveItems: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    canBeDeleted: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true,
+    },
+    private: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
     description: {
       type: DataTypes.STRING,
       allowNull: true,
@@ -75,6 +95,11 @@ UserMediaList.init(
         min: 0,
         max: MAX_USER_LISTS_INDEX,
       },
+    },
+    icon: {
+      type: DataTypes.ENUM(...USER_MEDIA_LIST_ICONS),
+      allowNull: false,
+      defaultValue: 'multi',
     },
     userId: {
       type: DataTypes.INTEGER,

--- a/server/src/models/users/userMediaList.ts
+++ b/server/src/models/users/userMediaList.ts
@@ -19,6 +19,7 @@ import {
   USER_MEDIA_LIST_ICONS,
   UserMediaListIcon,
 } from '../../../../shared/types/models';
+import { User } from '..';
 
 class UserMediaList extends Model<
   InferAttributes<UserMediaList>,
@@ -46,6 +47,10 @@ class UserMediaList extends Model<
       //so if we delete the list, all the items are also deleted
       onDelete: 'CASCADE',
       hooks: true,
+    });
+    this.belongsTo(User, {
+      as: 'user',
+      foreignKey: 'userId',
     });
   }
 }
@@ -150,6 +155,7 @@ UserMediaList.init(
     sequelize,
     underscored: true,
     modelName: 'user_media_list',
+    tableName: 'user_media_lists',
     indexes: [
       {
         unique: true,

--- a/server/src/models/users/userMediaListItem.ts
+++ b/server/src/models/users/userMediaListItem.ts
@@ -73,6 +73,7 @@ UserMediaListItem.init(
     sequelize,
     underscored: true,
     modelName: 'user_media_list_item',
+    tableName: 'user_media_list_items',
     indexes: [
       {
         unique: true,

--- a/server/src/services/user-media-list-service.ts
+++ b/server/src/services/user-media-list-service.ts
@@ -1,0 +1,46 @@
+import { Transaction } from 'sequelize';
+import {
+  DEF_LIST_FAV_FILMS,
+  DEF_LIST_FAV_SHOWS,
+  DEF_LIST_LIKES,
+  DEF_LIST_WATCHLIST,
+} from '../../../shared/constants/user-media-list-constants';
+import { CreateUserMediaList } from '../../../shared/types/models';
+import UserMediaList from '../models/users/userMediaList';
+
+export const createDefaultUserLists = async (
+  userId: number,
+  transaction?: Transaction
+): Promise<UserMediaList[]> => {
+  const defaultLists: CreateUserMediaList[] = [
+    createLikesList(userId),
+    createWatchlist(userId),
+    createFavFilmList(userId),
+    createFavTVList(userId),
+  ];
+  return await UserMediaList.bulkCreate(defaultLists, {
+    transaction,
+  });
+};
+export const createLikesList = (userId: number): CreateUserMediaList => ({
+  ...DEF_LIST_LIKES,
+  userId,
+  indexInUserLists: 0,
+});
+export const createWatchlist = (userId: number): CreateUserMediaList => ({
+  ...DEF_LIST_WATCHLIST,
+  userId,
+  indexInUserLists: 1,
+});
+
+export const createFavFilmList = (userId: number): CreateUserMediaList => ({
+  ...DEF_LIST_FAV_FILMS,
+  userId,
+  indexInUserLists: 2,
+});
+
+export const createFavTVList = (userId: number): CreateUserMediaList => ({
+  ...DEF_LIST_FAV_SHOWS,
+  userId,
+  indexInUserLists: 3,
+});

--- a/server/src/util/db/initialize-db.ts
+++ b/server/src/util/db/initialize-db.ts
@@ -1,7 +1,7 @@
 import { Sequelize } from 'sequelize';
 import { POSTGRES_URI } from '../config';
 import { MigrationMeta } from 'umzug';
-import { getMigrator } from './migrator-db';
+import { getMigrator, MIGRATIONS_ENABLED } from './migrator-db';
 
 const sequelize = new Sequelize(POSTGRES_URI, { logging: false });
 
@@ -10,7 +10,9 @@ const initializeDB = async () => {
     await sequelize.authenticate();
     console.log('Connected to Postgres DB');
     const pendingMigrations: MigrationMeta[] = await getMigrator().pending();
-    if (pendingMigrations.length > 0) {
+    if (!MIGRATIONS_ENABLED) {
+      console.log('Migrations are currently disabled.');
+    } else if (pendingMigrations.length > 0) {
       console.log(`Found ${pendingMigrations.length} pending Migrations!`);
       try {
         const migrations: MigrationMeta[] = await applyMigrations();

--- a/server/src/util/db/migrator-db.ts
+++ b/server/src/util/db/migrator-db.ts
@@ -3,6 +3,7 @@ import { PRODUCTION, PRODUCTION_MODE, ProductionMode } from '../config';
 import { sequelize } from './initialize-db';
 import { QueryInterface } from 'sequelize';
 let migrator: Umzug<QueryInterface> | null = null;
+export const MIGRATIONS_ENABLED: boolean = false;
 
 export type QueryInterfaceContext = { context: QueryInterface };
 

--- a/shared/constants/user-media-list-constants.ts
+++ b/shared/constants/user-media-list-constants.ts
@@ -47,7 +47,7 @@ export const DEF_LIST_LIKES: CreateUserMediaList = {
   userId: -1,
   autoCleanItems: true,
   private: false,
-  canBeDeleted: false,
+  canBeModified: false,
   icon: "like",
 };
 
@@ -57,7 +57,7 @@ export const DEF_LIST_WATCHLIST: CreateUserMediaList = {
   mediaTypes: [MediaType.Film, MediaType.Show, MediaType.Season],
   lockedMediaType: true,
   autoCleanItems: true,
-  canBeDeleted: false,
+  canBeModified: false,
   private: false,
   indexInUserLists: 1,
   userId: -1,
@@ -72,7 +72,7 @@ export const DEF_LIST_FAV_FILMS: CreateUserMediaList = {
   indexInUserLists: 2,
   userId: -1,
   autoCleanItems: false,
-  canBeDeleted: false,
+  canBeModified: false,
   private: false,
   icon: "fav-film",
 };
@@ -85,7 +85,7 @@ export const DEF_LIST_FAV_SHOWS: CreateUserMediaList = {
   indexInUserLists: 3,
   userId: -1,
   autoCleanItems: false,
-  canBeDeleted: false,
+  canBeModified: false,
   private: false,
   icon: "fav-show",
 };

--- a/shared/constants/user-media-list-constants.ts
+++ b/shared/constants/user-media-list-constants.ts
@@ -1,3 +1,6 @@
+import { MediaType } from "../types/media";
+import { CreateUserMediaList } from "../types/models";
+
 export const MAX_ITEMS_LIST_INDEX: number = 99;
 export const MAX_USER_LISTS_INDEX: number = 99;
 
@@ -6,3 +9,83 @@ export const MIN_LENGTH_NAME: number = 3;
 
 export const MAX_LENGTH_DESCRIPTION: number = 0;
 export const MIN_LENGTH_DESCRIPTION: number = 150;
+
+export const DEF_LIST_NEW: CreateUserMediaList = {
+  name: "My New List",
+  description: "",
+  mediaTypes: [MediaType.Film, MediaType.Show],
+  lockedMediaType: false,
+  autoCleanItems: false,
+  private: false,
+  indexInUserLists: -1,
+  userId: -1,
+  icon: "multi",
+};
+
+export const DEF_LIST_NEW_FILM: CreateUserMediaList = {
+  ...DEF_LIST_NEW,
+  name: "My New Film List",
+  mediaTypes: [MediaType.Film],
+  lockedMediaType: true,
+  icon: "film",
+};
+
+export const DEF_LIST_NEW_SHOW: CreateUserMediaList = {
+  ...DEF_LIST_NEW,
+  name: "My New TV List",
+  mediaTypes: [MediaType.Show],
+  lockedMediaType: true,
+  icon: "show",
+};
+
+export const DEF_LIST_LIKES: CreateUserMediaList = {
+  name: "Likes",
+  description: "My Liked Media",
+  mediaTypes: [MediaType.Show, MediaType.Film],
+  lockedMediaType: true,
+  indexInUserLists: 0,
+  userId: -1,
+  autoCleanItems: true,
+  private: false,
+  canBeDeleted: false,
+  icon: "like",
+};
+
+export const DEF_LIST_WATCHLIST: CreateUserMediaList = {
+  name: "Watchlist",
+  description: "What am I watching next?",
+  mediaTypes: [MediaType.Film, MediaType.Show, MediaType.Season],
+  lockedMediaType: true,
+  autoCleanItems: true,
+  canBeDeleted: false,
+  private: false,
+  indexInUserLists: 1,
+  userId: -1,
+  icon: "watchlist",
+};
+
+export const DEF_LIST_FAV_FILMS: CreateUserMediaList = {
+  name: "Favorite Films",
+  description: "My favorite Films",
+  mediaTypes: [MediaType.Film],
+  lockedMediaType: true,
+  indexInUserLists: 2,
+  userId: -1,
+  autoCleanItems: false,
+  canBeDeleted: false,
+  private: false,
+  icon: "fav-film",
+};
+
+export const DEF_LIST_FAV_SHOWS: CreateUserMediaList = {
+  name: "Favorite TV Shows",
+  description: "My favorite TV Shows",
+  mediaTypes: [MediaType.Show],
+  lockedMediaType: true,
+  indexInUserLists: 3,
+  userId: -1,
+  autoCleanItems: false,
+  canBeDeleted: false,
+  private: false,
+  icon: "fav-show",
+};

--- a/shared/constants/user-media-list-constants.ts
+++ b/shared/constants/user-media-list-constants.ts
@@ -7,8 +7,8 @@ export const MAX_USER_LISTS_INDEX: number = 99;
 export const MAX_LENGTH_NAME: number = 75;
 export const MIN_LENGTH_NAME: number = 3;
 
-export const MAX_LENGTH_DESCRIPTION: number = 0;
-export const MIN_LENGTH_DESCRIPTION: number = 150;
+export const MAX_LENGTH_DESCRIPTION: number = 150;
+export const MIN_LENGTH_DESCRIPTION: number = 0;
 
 export const DEF_LIST_NEW: CreateUserMediaList = {
   name: "My New List",

--- a/shared/types/models.ts
+++ b/shared/types/models.ts
@@ -251,3 +251,61 @@ export interface CreateMediaGenre {
   genreId: number;
   mediaType: MediaType;
 }
+
+export interface UserMediaListItemData {
+  id: number;
+  indexInList: number;
+  userListId: number;
+  userList?: UserMediaListData;
+  indexId: number;
+  indexMedia?: IndexMediaData;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export const USER_MEDIA_LIST_ICONS = [
+  "fav-film",
+  "fav-show",
+  "fav-multi",
+  "film",
+  "show",
+  "season",
+  "multi",
+  "like",
+  "watchlist",
+  "other",
+] as const;
+
+export type UserMediaListIcon = (typeof USER_MEDIA_LIST_ICONS)[number];
+
+export interface CreateUserMediaListItem
+  extends Omit<
+    UserMediaListItemData,
+    "id" | "indexMedia" | "userList" | "createdAt" | "updatedAt"
+  > {}
+
+export interface UserMediaListData {
+  id: number;
+  name: string;
+  description: string;
+  userId: number;
+  indexInUserLists: number;
+  mediaTypes: MediaType[];
+  lockedMediaType: boolean;
+  private: boolean;
+  autoCleanItems: boolean;
+  canBeDeleted: boolean;
+  icon: UserMediaListIcon;
+  createdAt?: Date;
+  updatedAt?: Date;
+  listItems?: UserMediaListItemData[];
+}
+
+export interface CreateUserMediaList
+  extends Omit<
+    UserMediaListData,
+    "id" | "listItems" | "createdAt" | "updatedAt" | "icon" | "canBeDeleted"
+  > {
+  icon?: UserMediaListIcon;
+  canBeDeleted?: boolean;
+}

--- a/shared/types/models.ts
+++ b/shared/types/models.ts
@@ -294,7 +294,7 @@ export interface UserMediaListData {
   lockedMediaType: boolean;
   private: boolean;
   autoCleanItems: boolean;
-  canBeDeleted: boolean;
+  canBeModified: boolean;
   icon: UserMediaListIcon;
   createdAt?: Date;
   updatedAt?: Date;
@@ -304,8 +304,8 @@ export interface UserMediaListData {
 export interface CreateUserMediaList
   extends Omit<
     UserMediaListData,
-    "id" | "listItems" | "createdAt" | "updatedAt" | "icon" | "canBeDeleted"
+    "id" | "listItems" | "createdAt" | "updatedAt" | "icon" | "canBeModified"
   > {
   icon?: UserMediaListIcon;
-  canBeDeleted?: boolean;
+  canBeModified?: boolean;
 }


### PR DESCRIPTION
This pull request introduces a new "User Media Lists" feature, enabling users to create, manage, and organize custom lists of media items (such as films and shows). The changes include database migrations, model updates, default list definitions, and service utilities to support this functionality.

**User Media Lists Feature**

- **Database Schema & Migrations**
  - Added migration to create two new tables: `user_media_lists` (stores user-defined lists with properties like name, icon, privacy, etc.) and `user_media_list_items` (stores items within each list). Enforced unique constraints and foreign key relationships. Includes proper up/down migration logic and ENUM type cleanup.

- **Model Enhancements**
  - Updated `UserMediaList` and `UserMediaListItem` models to match the new schema, including new fields (e.g., `icon`, `autoRemoveItems`, `canBeModified`, `private`) and associations (user-to-lists, list-to-items). Set correct table names and indexes. [[1]](diffhunk://#diff-1c5e592172c7009807359b6a8108b8ce1983a205cd90a718225c37275f78e165R18-R22) [[2]](diffhunk://#diff-1c5e592172c7009807359b6a8108b8ce1983a205cd90a718225c37275f78e165R34-R38) [[3]](diffhunk://#diff-1c5e592172c7009807359b6a8108b8ce1983a205cd90a718225c37275f78e165R51-R54) [[4]](diffhunk://#diff-1c5e592172c7009807359b6a8108b8ce1983a205cd90a718225c37275f78e165R73-R84) [[5]](diffhunk://#diff-1c5e592172c7009807359b6a8108b8ce1983a205cd90a718225c37275f78e165R104-R108) [[6]](diffhunk://#diff-1c5e592172c7009807359b6a8108b8ce1983a205cd90a718225c37275f78e165R158) [[7]](diffhunk://#diff-94fecbab144e913f971877eec42ea2c71747924a1e826d30b5af16040370c0aaR76)
  - Extended the `User` model to include a `userLists` association and updated its `associate` method. [[1]](diffhunk://#diff-5f74475706192d23384cc57e3baaceac7f1329f8579c9478e5d2a9c238b6cc81R11-R12) [[2]](diffhunk://#diff-5f74475706192d23384cc57e3baaceac7f1329f8579c9478e5d2a9c238b6cc81R24-R39)

- **Shared Types & Constants**
  - Defined TypeScript interfaces and constants for user media lists, list items, and default list configurations (e.g., Likes, Watchlist, Favorite Films/Shows). Introduced a set of valid icons for lists. [[1]](diffhunk://#diff-235e561ac4b4d708ee05c88a2a3fd6302058ccc058adad565ceb0fcb4b1e1b7aR254-R311) [[2]](diffhunk://#diff-c08300db81470c582811bec91b19a2acd2edce85ea70dfa1095d9c7769378652R1-R91)

**Supporting Infrastructure**

- **Service Utilities**
  - Added a service (`user-media-list-service.ts`) to generate and create default lists for new users using predefined templates.

- **Migration Controls**
  - Added a flag (`MIGRATIONS_ENABLED`) to allow enabling/disabling migrations and updated initialization logic to respect this flag. [[1]](diffhunk://#diff-b16b1dd712a1c5a0b5f6aa3f932f8ba4f38269d7aef5e2d095bfb36e782abeabR6) [[2]](diffhunk://#diff-2d64eec01b6bbc4c4746203cbd0bf952e539478e1a0b72d9871321152cdf0639L4-R4) [[3]](diffhunk://#diff-2d64eec01b6bbc4c4746203cbd0bf952e539478e1a0b72d9871321152cdf0639L13-R15)

These changes lay the groundwork for user-customizable media organization, including default lists, extensible list types, and robust database support.